### PR TITLE
jshint: bump version

### DIFF
--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -6,4 +6,4 @@ report-type: jslint
 properties:
   version:
     type: string
-    default: 2.3.0
+    default: 2.6.0


### PR DESCRIPTION
`2.3` was released 18 months ago, this changes the version to `2.6.0` which was released at the start of this year. Thanks!
